### PR TITLE
HACK: register satellite hosts one by one

### DIFF
--- a/ansible/configs/satellite-vm/software.yml
+++ b/ansible/configs/satellite-vm/software.yml
@@ -69,6 +69,7 @@
   hosts: satellite_hosts
   become: true
   gather_facts: true
+  serial: 1
   tasks:
     - when: configure_satellite
       include_role:


### PR DESCRIPTION
While https://bugzilla.redhat.com/1949698 is fixed, there are still
cases where the race condition can happen and result in failed
registrations.

Let's play on the safe side and register hosts one by one.

Co-Authored-By: Yifat Fani Makias <ymakias@redhat.com>

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
